### PR TITLE
TH-438: Origins > Integrate UI & logic of the linked fields feature

### DIFF
--- a/assets/component-combobox.js
+++ b/assets/component-combobox.js
@@ -12,14 +12,13 @@ if (!customElements.get("yc-combobox")) {
     }
 
     connectedCallback() {
-      this.setup();
-      this.attachListeners();
-      this.search && this.enableSearch();
-    }
-
-    setup() {
       const items = this.content.querySelectorAll("yc-combobox-item");
 
+      this.setup(items);
+      this.attachListeners();
+    }
+
+    setup(items, callback) {
       items.forEach((item) => {
         const { value } = item.attributes;
         const label = item.textContent.trim();
@@ -36,10 +35,12 @@ if (!customElements.get("yc-combobox")) {
               ${disabled ? "disabled" : ""} ${checked ? "checked" : ""} ${required ? "required" : ""} hidden>
           </label>`;
       });
+
+      this.onSelect(callback);
+      this.enableSearch();
     }
 
     attachListeners() {
-      this.onSelect();
       this.onTrigger();
       this.onClickOutSide();
     }
@@ -64,13 +65,14 @@ if (!customElements.get("yc-combobox")) {
       this.content.dataset.visible = visible;
     }
 
-    onSelect() {
+    onSelect(callback) {
       const options = this.content.querySelectorAll("label");
 
       options.forEach((opt) =>
-        opt.addEventListener("change", () => {
+        opt.addEventListener("change", (e) => {
           this.placeholder.textContent = opt.textContent.trim();
           this.toggleState(false);
+          callback.call(this, e);
         }),
       );
     }

--- a/assets/component-combobox.js
+++ b/assets/component-combobox.js
@@ -50,7 +50,6 @@ if (!customElements.get("yc-combobox")) {
       const noResultsMsg = this.search.getAttribute("no-results") || window.combobox.no_results;
       const searchInput = document.createElement("input");
       searchInput.type = "search";
-      searchInput.name = "search";
       searchInput.placeholder = placeholder;
 
       this.search.replaceWith(searchInput);

--- a/assets/component-combobox.js
+++ b/assets/component-combobox.js
@@ -37,7 +37,7 @@ if (!customElements.get("yc-combobox")) {
       });
 
       this.onSelect(callback);
-      this.enableSearch();
+      this.search && this.enableSearch();
     }
 
     attachListeners() {
@@ -72,7 +72,7 @@ if (!customElements.get("yc-combobox")) {
         opt.addEventListener("change", (e) => {
           this.placeholder.textContent = opt.textContent.trim();
           this.toggleState(false);
-          callback.call(this, e);
+          callback && callback.call(this, e);
         }),
       );
     }

--- a/assets/component-combobox.js
+++ b/assets/component-combobox.js
@@ -31,7 +31,7 @@ if (!customElements.get("yc-combobox")) {
         item.outerHTML = `
           <label role="option">
             <span>${label}</span>
-            <input type="radio" name="${this.getAttribute("name")}" value="${value?.value}" 
+            <input type="radio" name="${this.getAttribute("name")}" value="${value?.value}" data-value="${item.attributes["data-value"]?.value ?? ""}"
               ${disabled ? "disabled" : ""} ${checked ? "checked" : ""} ${required ? "required" : ""} hidden>
           </label>`;
       });

--- a/assets/component-combobox.js
+++ b/assets/component-combobox.js
@@ -46,8 +46,8 @@ if (!customElements.get("yc-combobox")) {
     }
 
     enableSearch() {
-      const placeholder = this.search.getAttribute("placeholder");
-      const noResultsMsg = this.search.getAttribute("no-results");
+      const placeholder = this.search.getAttribute("placeholder") || window.combobox.search;
+      const noResultsMsg = this.search.getAttribute("no-results") || window.combobox.no_results;
       const searchInput = document.createElement("input");
       searchInput.type = "search";
       searchInput.name = "search";

--- a/assets/component-linked-fields.js
+++ b/assets/component-linked-fields.js
@@ -22,7 +22,7 @@ class LinkedFields extends HTMLElement {
 
   async fetchOptions() {
     for (const type of LinkedFields.TYPES) {
-      await this.onFetch(type);
+      this[type] && (await this.onFetch(type));
     }
   }
 
@@ -58,7 +58,7 @@ class LinkedFields extends HTMLElement {
     if (type === "country") this.countryCode = value;
     if (type === "region") this.regionCode = value;
     for (const next of { country: LinkedFields.TYPES.slice(1), region: LinkedFields.TYPES.slice(2) }[type] || []) {
-      await this.onFetch(next);
+      this[next] && (await this.onFetch(next));
     }
   }
 

--- a/assets/component-linked-fields.js
+++ b/assets/component-linked-fields.js
@@ -40,11 +40,13 @@ class LinkedFields extends HTMLElement {
         region: index === 0,
         city: index === 0,
       };
+      const label = typeof opt === "string" ? opt : opt.name;
+      const value = typeof opt === "string" ? opt : opt.code;
 
       content.insertAdjacentHTML(
         "beforeend",
-        `<yc-combobox-item value="${typeof opt === "string" ? opt : opt.code}" ${isDefault[type] ? "checked" : ""}>
-            ${typeof opt === "string" ? opt : opt.name}
+        `<yc-combobox-item value="${label}" data-value="${value}" ${isDefault[type] ? "checked" : ""}>
+            ${label}
         </yc-combobox-item>`,
       );
     });
@@ -53,7 +55,7 @@ class LinkedFields extends HTMLElement {
   }
 
   async onChange(e, type) {
-    const value = e.target.value;
+    const value = e.target.dataset.value;
 
     if (type === "country") this.countryCode = value;
     if (type === "region") this.regionCode = value;

--- a/assets/component-linked-fields.js
+++ b/assets/component-linked-fields.js
@@ -1,0 +1,101 @@
+class LinkedFields extends HTMLElement {
+  static TYPES = ["country", "region", "city"];
+
+  constructor() {
+    super();
+    this.locale = document.documentElement.lang || "en";
+    this.countryCode = CUSTOMER_COUNTRY_CODE;
+    this.regionCode = null;
+
+    for (const name of LinkedFields.TYPES) {
+      this[name] = this.querySelector(`yc-combobox[name='${name}']`);
+    }
+  }
+
+  connectedCallback() {
+    this._render();
+  }
+
+  _render() {
+    this.fetchOptions();
+  }
+
+  async fetchOptions() {
+    for (const type of LinkedFields.TYPES) {
+      await this.onFetch(type);
+    }
+  }
+
+  setupOptions(type, options) {
+    const combobox = this[type];
+    const content = combobox.querySelector("yc-combobox-content");
+    const search = combobox.querySelector("input[type='search'");
+
+    content.innerHTML = "";
+    content.appendChild(search);
+
+    options.forEach((opt, index) => {
+      const isDefault = {
+        country: opt.code == this.countryCode,
+        region: index === 0,
+        city: index === 0,
+      };
+
+      content.insertAdjacentHTML(
+        "beforeend",
+        `<yc-combobox-item value="${typeof opt === "string" ? opt : opt.code}" ${isDefault[type] ? "checked" : ""}>
+            ${typeof opt === "string" ? opt : opt.name}
+        </yc-combobox-item>`,
+      );
+    });
+
+    combobox.setup(content.querySelectorAll("yc-combobox-item"), (e) => this.onChange(e, type));
+  }
+
+  async onChange(e, type) {
+    const value = e.target.value;
+
+    if (type === "country") this.countryCode = value;
+    if (type === "region") this.regionCode = value;
+    for (const next of { country: LinkedFields.TYPES.slice(1), region: LinkedFields.TYPES.slice(2) }[type] || []) {
+      await this.onFetch(next);
+    }
+  }
+
+  async onFetch(type) {
+    const fetchMap = {
+      country: () => youcanjs.misc.getCountries(this.locale),
+      region: () => youcanjs.misc.getCountryRegions(this.countryCode, this.locale),
+      city: () => youcanjs.misc.getCountryCities(this.countryCode, this.regionCode, this.locale),
+    };
+
+    this.setIsLoading(type, true);
+
+    try {
+      const response = await fetchMap[type]?.();
+      if (!response) throw new Error(`Unknown fetch type: ${type}`);
+
+      const map = {
+        country: () => this.setupOptions(type, response.countries),
+        region: () => {
+          this.regionCode = response.states[0].code;
+          this.setupOptions(type, response.states);
+        },
+        city: () => this.setupOptions(type, response.cities),
+      };
+
+      map[type]?.();
+    } catch (error) {
+      console.error(error);
+    } finally {
+      this.setIsLoading(type, false);
+    }
+  }
+
+  setIsLoading(type, is_loading) {
+    const trigger = this[type].querySelector("yc-combobox-trigger");
+    trigger.setAttribute("aria-disabled", is_loading);
+  }
+}
+
+customElements.define("yc-linked-fields", LinkedFields);

--- a/assets/featured-product.css
+++ b/assets/featured-product.css
@@ -233,6 +233,13 @@
   color:color-mix(in srgb, currentColor 80%, transparent);
   background-color:color-mix(in srgb, currentColor 5%, transparent);
 }
+.single-product yc-product-info .buy-button .buy-area .express-checkout .fields yc-linked-fields{
+  display:grid;
+  grid-gap:var(--gap-lg);
+  gap:var(--gap-lg);
+  grid-template-columns:repeat(2, 1fr);
+  grid-column:1/-1;
+}
 .single-product yc-product-info .buy-button .buy-area .express-checkout .fields .field{
   display:grid;
   grid-gap:var(--gap-sm);
@@ -258,7 +265,7 @@
 .single-product yc-product-info .buy-button .buy-area .express-checkout .fields .field:has(input[type=hidden]){
   display:none;
 }
-.single-product yc-product-info .buy-button .buy-area .express-checkout .fields .field:has(input:required, textarea:required) > label::after{
+.single-product yc-product-info .buy-button .buy-area .express-checkout .fields .field:has(input:required, textarea:required, yc-combobox[required]) > label::after{
   content:" *";
   color:var(--color-error-500);
 }

--- a/assets/featured-product.css
+++ b/assets/featured-product.css
@@ -240,6 +240,9 @@
   grid-template-columns:repeat(2, 1fr);
   grid-column:1/-1;
 }
+.single-product yc-product-info .buy-button .buy-area .express-checkout .fields > *:nth-last-child(2):nth-child(odd){
+  grid-column:1/-1;
+}
 .single-product yc-product-info .buy-button .buy-area .express-checkout .fields .field{
   display:grid;
   grid-gap:var(--gap-sm);
@@ -345,6 +348,9 @@
   }
   .single-product yc-product-info .buy-button .buy-area .express-checkout .fields{
     border-block-start:none;
+    grid-template-columns:1fr;
+  }
+  .single-product yc-product-info .buy-button .buy-area .express-checkout .fields yc-linked-fields{
     grid-template-columns:1fr;
   }
   .single-product:not([data-prevent-sticky]) yc-product-info .buy-button .buy-area .express-checkout{

--- a/assets/global.js
+++ b/assets/global.js
@@ -1,6 +1,7 @@
 // Constants
 const CURRENCY_SYMBOL = Dotshop.currency;
-const CUSTOMER_LOCALE = Dotshop.customer_locale;
+const CUSTOMER_LOCALE = Dotshop.customer_locale || "en-US";
+const CUSTOMER_COUNTRY_CODE = new Intl.Locale(CUSTOMER_LOCALE).region;
 const ON_CHANGE_DEBOUNCE_TIMER = 300;
 
 const PUB_SUB_EVENTS = {

--- a/assets/main.css
+++ b/assets/main.css
@@ -227,10 +227,11 @@ button[data-loading]::before,
   border-radius:var(--radius-circle);
   animation:spin 1s linear infinite;
 }
-button:disabled, button[data-disabled], button[data-loading],
+button:disabled, button[data-disabled], button[data-loading], button[aria-disabled=true],
 .yc-btn:disabled,
 .yc-btn[data-disabled],
-.yc-btn[data-loading]{
+.yc-btn[data-loading],
+.yc-btn[aria-disabled=true]{
   opacity:0.5;
   cursor:not-allowed;
   pointer-events:none;

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -10,6 +10,7 @@
     "choose_options": "حدد الخيارات",
     "choose_image": "اضغط لاختيار صورة",
     "search": "ابحث..",
+    "select": "اختر",
     "no-results": "لم يتم العثور على نتائج.",
     "countdown": {
       "days": "أيام",

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -10,6 +10,7 @@
     "choose_options": "حدد الخيارات",
     "choose_image": "اضغط لاختيار صورة",
     "search": "ابحث..",
+    "no-results": "لم يتم العثور على نتائج.",
     "countdown": {
       "days": "أيام",
       "hours": "ساعات",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -10,6 +10,7 @@
     "choose_options": "Choose options",
     "choose_image": "Click to choose an image",
     "search": "Search..",
+    "no-results": "No results found.",
     "countdown": {
       "days": "Days",
       "hours": "Hours",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -10,6 +10,7 @@
     "choose_options": "Choose options",
     "choose_image": "Click to choose an image",
     "search": "Search..",
+    "select": "Select",
     "no-results": "No results found.",
     "countdown": {
       "days": "Days",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -10,6 +10,7 @@
     "choose_options": "Choisir les options",
     "choose_image": "Clique pour sélectionner une image",
     "search": "Recherche..",
+    "no-results": "Aucun résultat trouvé.",
     "countdown": {
       "days": "Jours",
       "hours": "Heures",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -10,6 +10,7 @@
     "choose_options": "Choisir les options",
     "choose_image": "Clique pour sélectionner une image",
     "search": "Recherche..",
+    "select": "sélectionner",
     "no-results": "Aucun résultat trouvé.",
     "countdown": {
       "days": "Jours",

--- a/snippets/head-config.liquid
+++ b/snippets/head-config.liquid
@@ -156,6 +156,11 @@
 {{ 'youcan-js.min.js' | asset_url | script_tag_deferred }}
 {{ 'cart.js' | asset_url | script_tag_deferred }}
 
+{% if checkout.linked_fields %}
+  <script src="https://unpkg.com/@youcan/js@1.0.4/dist/index.umd.js" defer></script>
+  {{ 'component-linked-fields.js' | asset_url | script_tag_deferred }}
+{% endif %}
+
 {% if template.name != 'cart' and template.name != 'thankyou' and template.name != 'page' %}
   {{ 'product-card.css' | asset_url | stylesheet_tag }}
   {{ 'product-quick-view.css' | asset_url | stylesheet_tag }}

--- a/snippets/head-config.liquid
+++ b/snippets/head-config.liquid
@@ -172,7 +172,12 @@
     checkout: '{{ form.errors | first }}',
     insufficient_inventory: '{{ 'error_messages.insufficient_inventory' | t }}',
     rating_is_required: '{{ 'error_messages.rating_is_required' | t }}',
-    large_file: '{{ 'error_messages.large_file' | t }}'
+    large_file: '{{ 'error_messages.large_file' | t }}',
+  }
+
+  window.combobox = {
+    search: '{{ 'general.search' | t }}',
+    no_results: '{{ 'general.no-results' | t }}',
   }
 
   window.successStrings = {

--- a/snippets/variant-dropdown.liquid
+++ b/snippets/variant-dropdown.liquid
@@ -14,7 +14,7 @@
 <yc-variant name="dropdown">
   <yc-combobox name="{{ name }}">
     <yc-combobox-trigger class="yc-btn icon" role="button" tabindex="0" aria-haspopup="listbox">
-      <yc-combobox-value>{{ placeholder | default: 'Select' }}</yc-combobox-value>
+      <yc-combobox-value>{{ placeholder | default: 'general.select' | t }}</yc-combobox-value>
     </yc-combobox-trigger>
     <yc-combobox-content role="listbox">
       {% for option in options %}

--- a/snippets/yc-express-checkout.liquid
+++ b/snippets/yc-express-checkout.liquid
@@ -1,5 +1,5 @@
 {% for field in checkout.fields %}
-  {% if field.type == 'select' %}
+  {% if field.type == 'select' or checkout.linked_fields %}
     {{ 'component-combobox.css' | asset_url | stylesheet_tag }}
     {{ 'component-combobox.js' | asset_url | script_tag_deferred }}
     {% break %}
@@ -17,6 +17,9 @@
   Usage:
   {% render 'yc-express-checkout', variant_id: '045-dj8-30k-ws7', available: true, is_sticky: false %}
 {% endcomment %}
+
+{% assign linked_fields = 'country,region,city' %}
+{% assign has_linked_fields = checkout.linked_fields %}
 
 <form data-order-form>
   <yc-product-form
@@ -39,54 +42,62 @@
         <div class="fields" data-title="{{ 'product.buy_button.express_checkout.subtitle' | t }}">
           {% for field in checkout.fields %}
             {% assign field_name = field.name %}
+
             {% if field.custom %}
               {% assign field_name = 'extra_fields[' | append: field.name | append: ']' %}
             {% endif %}
-            <div class="field" data-field>
-              <label>{{ field.display_name }}</label>
-              {% case field.type %}
-                {% when 'text', 'number', 'hidden' %}
-                  <input
-                    type="{{ field.type }}"
-                    name="{{ field_name }}"
-                    value="{{ field.default_value }}"
-                    placeholder="{{ field.placeholder }}"
-                    {% if field.required %}
-                      required
-                    {% endif %}
-                  >
-                {% when 'textarea' %}
-                  <textarea
-                    name="{{ field_name }}"
-                    placeholder="{{ field.placeholder }}"
-                    {% if field.required %}
-                      required
-                    {% endif -%}
-                  ></textarea>
-                {% when 'select' %}
-                  <yc-combobox name="{{ field_name }}">
-                    <yc-combobox-trigger class="yc-btn icon" role="button" tabindex="0" aria-haspopup="listbox">
-                      <yc-combobox-value>{{ field.placeholder | default: 'Select' }}</yc-combobox-value>
-                    </yc-combobox-trigger>
-                    <yc-combobox-content role="listbox">
-                      {% for option in field.options %}
-                        <yc-combobox-item
-                          value="{{ option }}"
-                          {% if field.required %}
-                            required
-                          {% endif %}
-                          {% if option == field.default_value %}
-                            checked
-                          {% endif %}
-                        >
-                          {{- option -}}
-                        </yc-combobox-item>
-                      {% endfor %}
-                    </yc-combobox-content>
-                  </yc-combobox>
-              {% endcase %}
-            </div>
+
+            {% unless has_linked_fields and linked_fields contains field.name %}
+              <div class="field" data-field>
+                <label>{{ field.display_name }}</label>
+                {% case field.type %}
+                  {% when 'text', 'number', 'hidden' %}
+                    <input
+                      type="{{ field.type }}"
+                      name="{{ field_name }}"
+                      value="{{ field.default_value }}"
+                      placeholder="{{ field.placeholder }}"
+                      {% if field.required %}
+                        required
+                      {% endif %}
+                    >
+                  {% when 'textarea' %}
+                    <textarea
+                      name="{{ field_name }}"
+                      placeholder="{{ field.placeholder }}"
+                      {% if field.required %}
+                        required
+                      {% endif -%}
+                    ></textarea>
+                  {% when 'select' %}
+                    <yc-combobox name="{{ field_name }}">
+                      <yc-combobox-trigger class="yc-btn icon" role="button" tabindex="0" aria-haspopup="listbox">
+                        <yc-combobox-value>{{ field.placeholder | default: 'Select' }}</yc-combobox-value>
+                      </yc-combobox-trigger>
+                      <yc-combobox-content role="listbox">
+                        {% for option in field.options %}
+                          <yc-combobox-item
+                            value="{{ option }}"
+                            {% if field.required %}
+                              required
+                            {% endif %}
+                            {% if option == field.default_value %}
+                              checked
+                            {% endif %}
+                          >
+                            {{- option -}}
+                          </yc-combobox-item>
+                        {% endfor %}
+                      </yc-combobox-content>
+                    </yc-combobox>
+                {% endcase %}
+              </div>
+            {% endunless %}
           {% endfor %}
+
+          {% if has_linked_fields %}
+            {% render 'yc-linked-fields', fields: checkout.fields %}
+          {% endif %}
         </div>
       </div>
       <div class="place-order">

--- a/snippets/yc-express-checkout.liquid
+++ b/snippets/yc-express-checkout.liquid
@@ -72,7 +72,7 @@
                   {% when 'select' %}
                     <yc-combobox name="{{ field_name }}">
                       <yc-combobox-trigger class="yc-btn icon" role="button" tabindex="0" aria-haspopup="listbox">
-                        <yc-combobox-value>{{ field.placeholder | default: 'Select' }}</yc-combobox-value>
+                        <yc-combobox-value>{{ field.placeholder | default: 'general.select' | t }}</yc-combobox-value>
                       </yc-combobox-trigger>
                       <yc-combobox-content role="listbox">
                         {% for option in field.options %}

--- a/snippets/yc-linked-fields.liquid
+++ b/snippets/yc-linked-fields.liquid
@@ -25,7 +25,7 @@
             <yc-combobox-value>{{ field.placeholder | default: 'Select' }}</yc-combobox-value>
           </yc-combobox-trigger>
           <yc-combobox-content role="listbox">
-            <yc-combobox-search placeholder="Search.." no-results="No country found."></yc-combobox-search>
+            <yc-combobox-search placeholder="{{ 'general.search' | t }}" no-results="{{ 'general.no-results' | t }}"></yc-combobox-search>
           </yc-combobox-content>
         </yc-combobox>
       </div>

--- a/snippets/yc-linked-fields.liquid
+++ b/snippets/yc-linked-fields.liquid
@@ -1,10 +1,8 @@
-{{ 'component-linked-fields.js' | asset_url | script_tag_deferred }}
-
 {% comment %}
-  Renders a ...
+  Renders a list of linked fields, typically "country", "region", and "city" (optional)
 
   Accepts:
-  - fields: {Array} Fields
+  - fields: {Array} list of fields
 
   Usage:
   {% render 'yc-linked-fields', fields: [...] %}

--- a/snippets/yc-linked-fields.liquid
+++ b/snippets/yc-linked-fields.liquid
@@ -1,3 +1,5 @@
+{{ 'component-linked-fields.js' | asset_url | script_tag_deferred }}
+
 {% comment %}
   Renders a ...
 

--- a/snippets/yc-linked-fields.liquid
+++ b/snippets/yc-linked-fields.liquid
@@ -1,0 +1,13 @@
+{% comment %}
+  Renders a ...
+
+  Accepts:
+  - fields: {Array} Fields
+
+  Usage:
+  {% render 'yc-linked-fields', fields: [...] %}
+{% endcomment %}
+
+<yc-linked-fields>
+    
+</yc-linked-fields>

--- a/snippets/yc-linked-fields.liquid
+++ b/snippets/yc-linked-fields.liquid
@@ -17,7 +17,12 @@
     {% if linked_fields contains field.name %}
       <div class="field" data-field>
         <label>{{ field.display_name }}</label>
-        <yc-combobox name="{{ field.name }}">
+        <yc-combobox
+          name="{{ field.name }}"
+          {% if field.required %}
+            required
+          {% endif %}
+        >
           <yc-combobox-trigger class="yc-btn icon" role="button" tabindex="0" aria-haspopup="listbox">
             <yc-combobox-value>{{ field.placeholder | default: 'Select' }}</yc-combobox-value>
           </yc-combobox-trigger>

--- a/snippets/yc-linked-fields.liquid
+++ b/snippets/yc-linked-fields.liquid
@@ -8,6 +8,22 @@
   {% render 'yc-linked-fields', fields: [...] %}
 {% endcomment %}
 
+{% assign linked_fields = 'country,region,city' %}
+
 <yc-linked-fields>
-    
+  {% for field in fields %}
+    {% if linked_fields contains field.name %}
+      <div class="field" data-field>
+        <label>{{ field.display_name }}</label>
+        <yc-combobox name="{{ field.name }}">
+          <yc-combobox-trigger class="yc-btn icon" role="button" tabindex="0" aria-haspopup="listbox">
+            <yc-combobox-value>{{ field.placeholder | default: 'Select' }}</yc-combobox-value>
+          </yc-combobox-trigger>
+          <yc-combobox-content role="listbox">
+            <yc-combobox-search placeholder="Search.." no-results="No country found."></yc-combobox-search>
+          </yc-combobox-content>
+        </yc-combobox>
+      </div>
+    {% endif %}
+  {% endfor %}
 </yc-linked-fields>

--- a/snippets/yc-linked-fields.liquid
+++ b/snippets/yc-linked-fields.liquid
@@ -22,7 +22,7 @@
           {% endif %}
         >
           <yc-combobox-trigger class="yc-btn icon" role="button" tabindex="0" aria-haspopup="listbox">
-            <yc-combobox-value>{{ field.placeholder | default: 'Select' }}</yc-combobox-value>
+            <yc-combobox-value>{{ field.placeholder | default: 'general.select' | t }}</yc-combobox-value>
           </yc-combobox-trigger>
           <yc-combobox-content role="listbox">
             <yc-combobox-search placeholder="{{ 'general.search' | t }}" no-results="{{ 'general.no-results' | t }}"></yc-combobox-search>

--- a/styles/base/_common.scss
+++ b/styles/base/_common.scss
@@ -103,7 +103,8 @@ button,
 
   &:disabled,
   &[data-disabled],
-  &[data-loading] {
+  &[data-loading],
+  &[aria-disabled="true"] {
     opacity: 0.5;
     cursor: not-allowed;
     pointer-events: none;

--- a/styles/featured-product.scss
+++ b/styles/featured-product.scss
@@ -268,6 +268,13 @@
               background-color: color-mix(in srgb, currentColor 5%, transparent);
             }
 
+            yc-linked-fields {
+              display: grid;
+              gap: var(--gap-lg);
+              grid-template-columns: repeat(2, 1fr);
+              grid-column: 1 / -1;
+            }
+
             .field {
               display: grid;
               gap: var(--gap-sm);
@@ -297,7 +304,7 @@
                 display: none;
               }
 
-              &:has(input:required, textarea:required) > label::after {
+              &:has(input:required, textarea:required, yc-combobox[required]) > label::after {
                 content: " *";
                 color: var(--color-error-500);
               }

--- a/styles/featured-product.scss
+++ b/styles/featured-product.scss
@@ -275,6 +275,10 @@
               grid-column: 1 / -1;
             }
 
+            & > *:nth-last-child(2):nth-child(odd) {
+              grid-column: 1 / -1;
+            }
+
             .field {
               display: grid;
               gap: var(--gap-sm);
@@ -407,6 +411,10 @@
           .fields {
             border-block-start: none;
             grid-template-columns: 1fr;
+
+            yc-linked-fields {
+              grid-template-columns: 1fr;
+            }
           }
         }
       }


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH-438](https://youcanshop.atlassian.net/browse/TH-438).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run zip`
* [ ] a new file will be generated in this format `theme name + date + .zip` in `/dist`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Go to Settings (`seller area`) -> [Payment](https://seller-area.youcan.shop/admin/settings/payment) -> Checkout information
* [ ] Enable the `Linked fields` option
* [ ] Go to Store -> Themes > Customize (`Origins` _dev_)
* [ ] In `global settings`, set the checkout type to Express Checkout`
* [ ] Go back to your `storefront` (assuming you've `Origins` theme activated)
* [ ] Go to any product page. The `express checkout` now shows fields for `country`, `region`, and `city`. Interact with them to check for any issues.

## Preview
![linked-fields](https://github.com/user-attachments/assets/942c9c5f-d188-44a3-97c4-920a25d1b863)



## Note

Leave empty when you have nothing to say.


[TH-438]: https://youcanshop.atlassian.net/browse/TH-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ