### PR TITLE
TH-417: yc-dropdown: Fix the dropdown trigger width issue with long p…

### DIFF
--- a/assets/component-combobox.css
+++ b/assets/component-combobox.css
@@ -15,10 +15,12 @@ yc-combobox yc-combobox-trigger.yc-btn.icon{
           user-select:none;
   font-size:var(--text-sm);
   padding:8px 12px;
+  display:grid;
+  grid-template-columns:auto auto;
   justify-content:space-between;
 }
 yc-combobox yc-combobox-trigger.yc-btn.icon yc-combobox-value{
-  width:90%;
+  width:100%;
   overflow:hidden;
   white-space:nowrap;
   text-overflow:ellipsis;

--- a/assets/component-combobox.css
+++ b/assets/component-combobox.css
@@ -78,6 +78,12 @@ yc-combobox yc-combobox-content input[type=search]{
   border-block-end:1px solid color-mix(in srgb, currentColor 8%, transparent) !important;
 }
 yc-combobox yc-combobox-content label{
+  display:grid;
+  grid-gap:var(--gap-lg);
+  gap:var(--gap-lg);
+  grid-template-columns:auto auto;
+  align-items:center;
+  justify-content:space-between;
   padding:8px 12px;
   position:relative;
   margin-inline:4px;
@@ -87,10 +93,8 @@ yc-combobox yc-combobox-content label{
 }
 yc-combobox yc-combobox-content label span{
   overflow:hidden;
-  display:-webkit-box;
-  -webkit-line-clamp:1;
+  white-space:nowrap;
   text-overflow:ellipsis;
-  -webkit-box-orient:vertical;
 }
 yc-combobox yc-combobox-content label:first-child{
   margin-block-start:4px;

--- a/assets/component-combobox.js
+++ b/assets/component-combobox.js
@@ -29,7 +29,7 @@ if (!customElements.get("yc-combobox")) {
         if (checked) this.placeholder.textContent = label;
 
         item.outerHTML = `
-          <label role="option">
+          <label role="option" title="${label}">
             <span>${label}</span>
             <input type="radio" name="${this.getAttribute("name")}" value="${value?.value}" data-value="${item.attributes["data-value"]?.value ?? ""}"
               ${disabled ? "disabled" : ""} ${checked ? "checked" : ""} ${required ? "required" : ""} hidden>

--- a/styles/component-combobox.scss
+++ b/styles/component-combobox.scss
@@ -14,10 +14,12 @@ yc-combobox {
     user-select: none;
     font-size: var(--text-sm);
     padding: 8px 12px;
+    display: grid;
+    grid-template-columns: auto auto;
     justify-content: space-between;
 
     yc-combobox-value {
-      width: 90%;
+      width: 100%;
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;

--- a/styles/component-combobox.scss
+++ b/styles/component-combobox.scss
@@ -86,6 +86,11 @@ yc-combobox {
     }
 
     label {
+      display: grid;
+      gap: var(--gap-lg);
+      grid-template-columns: auto auto;
+      align-items: center;
+      justify-content: space-between;
       padding: 8px 12px;
       position: relative;
       margin-inline: 4px;
@@ -95,10 +100,8 @@ yc-combobox {
 
       span {
         overflow: hidden;
-        display: -webkit-box;
-        -webkit-line-clamp: 1;
+        white-space: nowrap;
         text-overflow: ellipsis;
-        -webkit-box-orient: vertical;
       }
 
       &:first-child {


### PR DESCRIPTION
…laceholder text

## JIRA Ticket

Ticket: [TH-417](https://youcanshop.atlassian.net/browse/TH-417).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run zip`
* [ ] a new file will be generated in this format `theme name + date + .zip` in `/dist`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Go to Settings (`seller area`) -> [Payment](https://seller-area.youcan.shop/admin/settings/payment) -> Checkout information
* [ ] Enable the `Linked fields` option
* [ ] Go to Store -> [Themes](https://seller-area.youcan.shop/admin/themes) > Customize (`Origins` _dev_)
* [ ] In `global settings`, set the checkout type to Express Checkout`
* [ ] Go back to your `storefront` (assuming you've `Origins` theme activated)
* [ ] Go to any product page
* [ ] Choose a select component, insert a long text into `yc-select-value` via dev tools, and see if it still looks right

<img width="667" alt="Screenshot 2025-05-09 at 11 21 38" src="https://github.com/user-attachments/assets/dfbea322-0397-4a1e-bef1-a48a17770442" />


## Note

Leave empty when you have nothing to say.


[TH-417]: https://youcanshop.atlassian.net/browse/TH-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ