### PR TITLE
TH-474: Make product and collections images responsive

### DIFF
--- a/snippets/collection-card.liquid
+++ b/snippets/collection-card.liquid
@@ -33,7 +33,7 @@
           33vw
         "
         src="{{ collection.preview_image.original }}"
-        alt="{{ collection.name }}"
+        alt=""
         loading="lazy"
       >
     {% else %}

--- a/snippets/collection-card.liquid
+++ b/snippets/collection-card.liquid
@@ -21,8 +21,14 @@
       <img
         width="100%"
         height="100%"
-        alt=""
-        src="{{ collection.image }}"
+        srcset="
+          {{ collection.preview_image.small }} 480w,
+          {{ collection.preview_image.medium }} 800w,
+          {{ collection.preview_image.large }} 1200w,
+          {{ collection.preview_image.original }} 1600w
+        "
+        src="{{ collection.preview_image.original }}"
+        alt="{{ collection.name }}"
         loading="lazy"
       >
     {% else %}

--- a/snippets/collection-card.liquid
+++ b/snippets/collection-card.liquid
@@ -22,10 +22,15 @@
         width="100%"
         height="100%"
         srcset="
-          {{ collection.preview_image.small }} 480w,
-          {{ collection.preview_image.medium }} 800w,
-          {{ collection.preview_image.large }} 1200w,
-          {{ collection.preview_image.original }} 1600w
+          {{ collection.preview_image.medium }} 480w,
+          {{ collection.preview_image.large }} 800w,
+          {{ collection.preview_image.original }} 1200w
+        "
+        sizes="
+          (max-width: 640px) 50vw,
+          (max-width: 768px) 33vw,
+          (max-width: 1024px) 25vw,
+          33vw
         "
         src="{{ collection.preview_image.original }}"
         alt="{{ collection.name }}"

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -20,17 +20,15 @@
         height="100%"
         width="100%"
         srcset="
-          {{ product.preview_image.small }} 480w,
-          {{ product.preview_image.medium }} 800w,
-          {{ product.preview_image.large }} 1200w,
-          {{ product.preview_image.original }} 1600w
+          {{ product.preview_image.medium }} 480w,
+          {{ product.preview_image.large }} 800w,
+          {{ product.preview_image.original }} 1200w
         "
         sizes="
-          (max-width: 640px) 100vw,
-          (max-width: 768px) 80vw,
-          (max-width: 1024px) 60vw,
-          (max-width: 1280px) 50vw,
-          40vw
+          (max-width: 640px) 50vw,
+          (max-width: 768px) 33vw,
+          (max-width: 1024px) 25vw,
+          33vw
         "
         src="{{ product.preview_image.original }}"
         alt="{{ product.name }}"

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -19,7 +19,20 @@
         loading="lazy"
         height="100%"
         width="100%"
-        src="{{ product.thumbnail }}"
+        srcset="
+          {{ product.preview_image.small }} 480w,
+          {{ product.preview_image.medium }} 800w,
+          {{ product.preview_image.large }} 1200w,
+          {{ product.preview_image.original }} 1600w
+        "
+        sizes="
+          (max-width: 640px) 100vw,
+          (max-width: 768px) 80vw,
+          (max-width: 1024px) 60vw,
+          (max-width: 1280px) 50vw,
+          40vw
+        "
+        src="{{ product.preview_image.original }}"
         alt="{{ product.name }}"
       >
     {% else %}


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH-474](https://youcanshop.atlassian.net/browse/TH-474).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run zip`
* [ ] a new file will be generated in this format `theme name + date + .zip` in `/dist`
* [ ] Upload generated file locally or in seller-area test env

## Steps to reproduce
* [ ] Go to theme editor
* [ ] Add a products or products by collection section
* [ ] Modify the number of columns, set it to 2
* [ ] The product images will appear blurry:
![image](https://github.com/user-attachments/assets/57623098-3bea-44e1-a392-765598905748)


## QA Steps
* [ ] Go to theme editor
* [ ] Add a products or products by collection section
* [ ] Modify the number of columns, set it to 2
* [ ] The images should not be blurry
* [ ] Open the browser's devtools
* [ ] Resize the screen to a mobile screen
* [ ] Inspect the image in the product card, make sure you select the image not the <a> wrapping it
* [ ] Now switch to the console tab and input the following code: `$0.currentSrc`
* [ ] Ensure that the src is the `_lg` image variant

## Note

Leave empty when you have nothing to say.


[TH-474]: https://youcanshop.atlassian.net/browse/TH-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ