### PR TITLE
TH-513: Origins > Express checkout > Fix the incorrect fields listing view

### DIFF
--- a/assets/featured-product.css
+++ b/assets/featured-product.css
@@ -234,14 +234,10 @@
   background-color:color-mix(in srgb, currentColor 5%, transparent);
 }
 .single-product yc-product-info .buy-button .buy-area .express-checkout .fields yc-linked-fields{
-  display:grid;
-  grid-gap:var(--gap-lg);
-  gap:var(--gap-lg);
-  grid-template-columns:repeat(2, 1fr);
-  grid-column:1/-1;
+  display:contents;
 }
-.single-product yc-product-info .buy-button .buy-area .express-checkout .fields > *:nth-last-child(2):nth-child(odd){
-  grid-column:1/-1;
+.single-product yc-product-info .buy-button .buy-area .express-checkout .fields yc-linked-fields .field:last-child:nth-child(odd){
+  grid-column:unset !important;
 }
 .single-product yc-product-info .buy-button .buy-area .express-checkout .fields .field{
   display:grid;

--- a/styles/featured-product.scss
+++ b/styles/featured-product.scss
@@ -269,14 +269,11 @@
             }
 
             yc-linked-fields {
-              display: grid;
-              gap: var(--gap-lg);
-              grid-template-columns: repeat(2, 1fr);
-              grid-column: 1 / -1;
-            }
+              display: contents;
 
-            & > *:nth-last-child(2):nth-child(odd) {
-              grid-column: 1 / -1;
+            .field:last-child:nth-child(odd) {
+              grid-column: unset !important;
+            }
             }
 
             .field {


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH-513](https://youcanshop.atlassian.net/browse/TH-513).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run zip`
* [ ] a new file will be generated in this format `theme name + date + .zip` in `/dist`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Go to /something
* [ ] Verify said thing


### Screenshots
Linked fields ON & last child single
(I tried to make it full but its kind hard couldn't reach it any proposal solution can be in comments?)
<img width="891" alt="Screenshot 2025-05-22 at 15 58 23" src="https://github.com/user-attachments/assets/aec8db7e-04a0-4804-aab5-9963cf0d22bb" />


Linked fields ON &  last child isn't single
<img width="891" alt="Screenshot 2025-05-22 at 15 59 09" src="https://github.com/user-attachments/assets/14bbb84b-a580-4013-b579-18799a65a590" />


Linked fields OFF & last child single
<img width="891" alt="Screenshot 2025-05-22 at 16 00 01" src="https://github.com/user-attachments/assets/e7d9de1d-1ed6-406a-8d0b-6212567b4414" />


Linked fields OFF & last child isn't single
<img width="891" alt="Screenshot 2025-05-22 at 16 00 51" src="https://github.com/user-attachments/assets/3e3916ce-92fb-4ec2-9620-11f8a05b7936" />

## Note

Leave empty when you have nothing to say.
