### PR TITLE
SF-574: fix slideshow and upsell duplicate prop labels

### DIFF
--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -296,7 +296,7 @@
     {
       "id": "space_bottom",
       "type": "range",
-      "label": "t:common.spacing.space_top",
+      "label": "t:common.spacing.space_bottom",
       "min": 0,
       "max": 200,
       "step": 10,

--- a/sections/upsell.liquid
+++ b/sections/upsell.liquid
@@ -93,7 +93,7 @@
     {
       "id": "space_bottom",
       "type": "range",
-      "label": "t:common.spacing.space_top",
+      "label": "t:common.spacing.space_bottom",
       "min": 0,
       "max": 200,
       "step": 10,


### PR DESCRIPTION
## JIRA Ticket

Ticket: [SF-574](https://youcanshop.atlassian.net/browse/SF-574).

## QA Steps

* [ ] Add a slideshow to your theme
* [ ] Click on the slideshow section to customize it
* [ ] Scroll to the bottom of the section properties
* [ ] Ensure that there are no double "Space top" labels and instead you see "Space top" and "Space bottom"
* [ ] Switch to the Upsell page
* [ ] Ensure the same thing for the upsell section

## Note

Leave empty when you have nothing to say.


[SF-574]: https://youcanshop.atlassian.net/browse/SF-574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ