### PR TITLE
chore: settings > control variants preselect

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -503,6 +503,21 @@
     ]
   },
   {
+    "label": "t:settings_schema.product.label",
+    "settings": [
+      {
+        "type": "header",
+        "content": "t:settings_schema.product.variants"
+      },
+      {
+        "type": "checkbox",
+        "id": "enable_preselect_first_available_variant",
+        "label": "t:settings_schema.product.preselect",
+        "default": true
+      }
+    ]
+  },
+  {
     "label": "t:settings_schema.checkout.label",
     "settings": [
       {

--- a/locales/ar.schema.json
+++ b/locales/ar.schema.json
@@ -124,6 +124,11 @@
       "badge_background_color": "لون خلفية الشارة",
       "position_on_card": "الموقع على البطاقة"
     },
+    "product": {
+      "label": "المنتج",
+      "variants": "المتغيرات",
+      "preselect": "حدد مسبقا المتغير الأول المتاح"
+    },
     "checkout": {
       "label": "الدفع",
       "types": "الأنواع",

--- a/locales/en.schema.default.json
+++ b/locales/en.schema.default.json
@@ -124,6 +124,11 @@
       "badge_background_color": "Badge background color",
       "position_on_card": "Position on card"
     },
+    "product": {
+      "label": "Product",
+      "variants": "Variants",
+      "preselect": "Preselect first available variant"
+    },
     "checkout": {
       "label": "Checkout",
       "types": "Types",

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -124,6 +124,11 @@
       "badge_background_color": "Couleur d'arrière-plan du badge",
       "position_on_card": "Position sur la carte"
     },
+    "product": {
+      "label": "Produit",
+      "variants": "Variantes",
+      "preselect": "Présélectionnez la première variante disponible"
+    },
     "checkout": {
       "label": "Paiement",
       "types": "Types",

--- a/snippets/variant-color.liquid
+++ b/snippets/variant-color.liquid
@@ -20,7 +20,7 @@
         type="radio"
         name="{{ name }}"
         value="{{ option.value }}"
-        {% if option.value == default_value %}
+        {% if option.value == default_value and settings.enable_preselect_first_available_variant %}
           checked
         {% endif %}
       >

--- a/snippets/variant-dropdown.liquid
+++ b/snippets/variant-dropdown.liquid
@@ -20,7 +20,7 @@
       {% for option in options %}
         <yc-combobox-item
           value="{{ option }}"
-          {% if option == default_value %}
+          {% if option == default_value and settings.enable_preselect_first_available_variant %}
             checked
           {% endif %}
         >

--- a/snippets/variant-image.liquid
+++ b/snippets/variant-image.liquid
@@ -23,7 +23,7 @@
         type="radio"
         name="{{ name }}"
         value="{{ option.value }}"
-        {% if option.value == default_value %}
+        {% if option.value == default_value and settings.enable_preselect_first_available_variant %}
           checked
         {% endif %}
       >

--- a/snippets/variant-radio.liquid
+++ b/snippets/variant-radio.liquid
@@ -17,7 +17,7 @@
         type="radio"
         name="{{ name }}"
         value="{{ option }}"
-        {% if option == default_value %}
+        {% if option == default_value and settings.enable_preselect_first_available_variant %}
           checked
         {% endif %}
       >

--- a/snippets/variant-toggle.liquid
+++ b/snippets/variant-toggle.liquid
@@ -18,7 +18,7 @@
         type="radio"
         name="{{ name }}"
         value="{{ option }}"
-        {% if option == default_value %}
+        {% if option == default_value and settings.enable_preselect_first_available_variant %}
           checked
         {% endif %}
       >


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH_X](https://youcanshop.atlassian.net/browse/TH_X).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run zip`
* [ ] a new file will be generated in this format `theme name + date + .zip` in `/dist`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Go to your storefront (`Origins` as your active theme)
* [ ] In your theme editor, global settings > product, try to enable/disable variants preselect option
* [ ] Verify if your choice applied on all store variants (product page, feature product, quick view..)
 
## Preview
| Enabled | Disabled |
|--------|--------|
| <img width="359" height="165" alt="Screenshot 2026-06-29 at 12 18 02" src="https://github.com/user-attachments/assets/07e819f0-ac56-45ad-bbf4-a06f30b1fb16" /> | <img width="359" height="165" alt="Screenshot 2026-06-29 at 12 18 25" src="https://github.com/user-attachments/assets/65e875ef-551c-4e49-a277-79409e29a011" /> |
| <img width="362" height="172" alt="Screenshot 2026-06-29 at 12 22 35" src="https://github.com/user-attachments/assets/9a018455-2ada-4a94-85d0-58854f839f97" /> | <img width="359" height="165" alt="Screenshot 2026-06-29 at 12 18 32" src="https://github.com/user-attachments/assets/60bea17c-77d3-4f41-9cdb-2c6c632e7d29" /> | 


## Note

Leave empty when you have nothing to say.
